### PR TITLE
Zeiss reader

### DIFF
--- a/Wrappers/Python/cil/io/ZEISSDataReader.py
+++ b/Wrappers/Python/cil/io/ZEISSDataReader.py
@@ -1,122 +1,166 @@
-from cil.framework import AcquisitionData, AcquisitionGeometry, ImageData, ImageGeometry
+# -*- coding: utf-8 -*-
+#   This work is part of the Core Imaging Library (CIL) developed by CCPi 
+#   (Collaborative Computational Project in Tomographic Imaging), with 
+#   substantial contributions by UKRI-STFC and University of Manchester.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+#   Authored by:    Jakob S. Jørgensen (DTU)
+#                   Andrew
+#                   Edoardo Pasca (UKRI-STFC)
+#                   Gemma Fardell (UKRI-STFC)
+
+
+from cil.framework import AcquisitionData, AcquisitionGeometry, ImageData, ImageGeometry, DataOrder
 import numpy as np
 import os
 import olefile
 import logging
 import dxchange
+import warnings
+
+logger = logging.getLogger(__name__)
 
 class ZEISSDataReader(object):
     
-    def __init__(self, 
-                 **kwargs):
+    def __init__(self, file_name=None, roi=None):
         '''
         Constructor
         
         :param file_name: file name to read
-        :type file_name: os.path or string, default None
-        :param angle_unit: describe what the unit is, angle or degree
-        :type angle_unit: string, default degree
-        :param logging_level: Logging messages which are less severe than level will be ignored.
-        :type logging_level: int, default 40 i.e. ERROR, possible values are 0 10 20 30 40 50 https://docs.python.org/3/library/logging.html#levels
-        :param roi: dictionary with roi to load 
-                {'axis_0': (start, end, step), 
-                 'axis_1': (start, end, step), 
-                 'axis_2': (start, end, step)}
-                Files are stacked along axis_0. axis_1 and axis_2 correspond
-                to row and column dimensions, respectively.
-                Files are stacked in alphabetic order. 
-                To skip files or to change number of files to load, 
-                adjust axis_0. For instance, 'axis_0': (100, 300)
+        :type file_name: os.path or string
+        :param roi: dictionary with roi to load for each axis.
+                {'axis_labels_1': (start, end, step), 
+                 'axis_labels_2': (start, end, step)}
+                axis_labels are definied by ImageGeometry and AcquisitionGeometry dimension labels.
+                e.g. for ImageData to skip files or to change number of files to load, 
+                adjust 'vertical'. For instance, 'vertical': (100, 300)
                 will skip first 100 files and will load 200 files.
-                'axis_0': -1 is a shortcut to load all elements along axis.
+                'axis_label': -1 is a shortcut to load all elements along axis.
                 Start and end can be specified as None which is equivalent 
                 to start = 0 and end = load everything to the end, respectively.
-                Start and end also can be negative.
+                Start and end also can be negative using numpy indexing.
         :type roi: dictionary, default None
-                    
+
         '''
+        # Set logging level for dxchange reader.py
+        logger_dxchange = logging.getLogger(name='dxchange.reader')
+        if logger_dxchange is not None:
+            logger_dxchange.setLevel(logging.ERROR)
+
+        if file_name is not None:
+            self.set_up(file_name = file_name, roi = roi)
+
+    @property
+    def file_name(self):
+        return self._file_name
+
+    def set_file_name(self, file_name):
+        # check if file exists
+        file_name = os.path.abspath(file_name)
+        if not(os.path.isfile(file_name)):
+            raise FileNotFoundError('{}'.format(file_name))
         
-        self.file_name = kwargs.get('file_name', None)
-        angle_unit = kwargs.get('angle_unit', AcquisitionGeometry.DEGREE)
-        level = kwargs.get('logging_level', 40)
-        self.roi = kwargs.get('roi', None)
-        if self.file_name is not None:
-            self.set_up(file_name = self.file_name, roi = self.roi, angle_unit=angle_unit, logging_level=level)
+        file_type = os.path.basename(file_name).split('.')[-1].lower()
+        if file_type not in ['txrm','txm']:
+            raise TypeError('This reader can only process TXRM or TXM files. Got {}'.format(os.path.basename(self.file_name)))
+
+        self._file_type = file_type
+        self._file_name = file_name
+
+
+    @property
+    def full_roi(self):
+
+        default_roi = [ [0,self._metadata_full['number_of_images'],1], 
+                        [0,self._metadata_full['image_height'],1],
+                        [0,self._metadata_full['image_width'],1]] 
+
+        return default_roi
+
+
+    @property
+    def roi(self):
+        return self._roi
+
+    def set_roi(self, roi=None):
+
+        if roi == None:
+            self._roi = roi
+        else:
+
+            if self._file_type == 'txrm':
+                allowed_labels = DataOrder.CIL_AG_LABELS
+                zeis_data_order = {'angle':0, 'vertical':1, 'horizontal':2}
+            else:
+                allowed_labels = DataOrder.CIL_IG_LABELS
+                zeis_data_order = {'vertical':0, 'horizontal_y':1, 'horizontal_x':2}
+
+            # check roi labels and create tuple for slicing    
+            roi_tmp = self.full_roi.copy()   
+
+            for key in roi.keys():
+                if key not in allowed_labels:
+                    raise Exception("Wrong label. Expected dimension labels in {0}, {1}, {2}, Got {}".format(**self.full_roi.keys()), key)
+
+                idx = zeis_data_order[key]
+                if roi[key] != -1:
+                    for i, x in enumerate(roi[key]):
+                        if x is None:
+                            continue
+
+                        if i != 2: #start and stop
+                            roi_tmp[idx][i] = x if x >= 0 else roi_tmp[idx][1] - x
+                        else: #step
+                            roi_tmp[idx][i] =  x if x > 0 else 1
+                                
+            self._roi = roi_tmp
+
 
     def set_up(self, 
-               file_name = None,
-               angle_unit = AcquisitionGeometry.DEGREE,
-               logging_level=40,
+               file_name,
                roi = None):
         '''Set up the reader
         
         :param file_name: file name to read
         :type file_name: os.path or string, default None
-        :param slice_range: list with range to slice data, [start,stop,step(optional)]
-        :type slice_range: list, default None
-        :param angle_unit: describe what the unit is, angle or degree
-        :type angle_unit: string, default degree
-        :param logging_level: Logging messages which are less severe than level will be ignored.
-        :type logging_level: int, default 40 i.e. ERROR, possible values are 0 10 20 30 40 50 https://docs.python.org/3/library/logging.html#levels
-                :param roi: dictionary with roi to load 
-                {'axis_0': (start, end, step), 
-                 'axis_1': (start, end, step), 
-                 'axis_2': (start, end, step)}
-                Files are stacked along axis_0. axis_1 and axis_2 correspond
-                to row and column dimensions, respectively.
-                Files are stacked in alphabetic order. 
-                To skip files or to change number of files to load, 
-                adjust axis_0. For instance, 'axis_0': (100, 300)
+        :param roi: dictionary with roi to load for each axis.
+                {'axis_labels_1': (start, end, step), 
+                 'axis_labels_2': (start, end, step)}
+                axis_labels are definied by ImageGeometry and AcquisitionGeometry dimension labels.
+                e.g. for ImageData to skip files or to change number of files to load, 
+                adjust 'vertical'. For instance, 'vertical': (100, 300)
                 will skip first 100 files and will load 200 files.
-                'axis_0': -1 is a shortcut to load all elements along axis.
+                'axis_label': -1 is a shortcut to load all elements along axis.
                 Start and end can be specified as None which is equivalent 
                 to start = 0 and end = load everything to the end, respectively.
-                Start and end also can be negative.
-        :type roi: dictionary, default None'''
+                Start and end also can be negative using numpy indexing.
+        :type roi: dictionary, default None
+        '''
 
-        # Set logging level for dxchange reader.py
-        self.logging_level = logging_level
-        logger = logging.getLogger(name='dxchange.reader')
-        if logger is not None:
-            logger.setLevel(self.logging_level)
-        
-        self.file_name = os.path.abspath(file_name)
-        
-        # Check if file path and supsequent file exists
-        if self.file_name == None:
-            raise ValueError('Path to txrm file is required.')
-        
-        if not(os.path.isfile(self.file_name)):
-            raise FileNotFoundError('{}'.format(self.file_name))
-        
-        # Set type of units for theta/angle
-        possible_units = [AcquisitionGeometry.DEGREE, AcquisitionGeometry.RADIAN]
-        if angle_unit in possible_units:
-            self.angle_unit = angle_unit
-        else:
-            raise ValueError('angle_unit should be one of {}'.format(possible_units))
+        self.set_file_name(file_name)
 
-        metadata = self.read_metadata()
+        self._metadata_full = self.read_metadata()
+    
+        self.set_roi(roi)
 
-        self.roi = roi
-        # check roi labels and create tuple for slicing
-        default_roi = {'axis_0': (0,metadata['number_of_images'],1), 
-               'axis_1': (0,metadata['image_height'],1),
-               'axis_2': (0,metadata['image_width'],1)}
         if self.roi:       
-            for key in self.roi.keys():
-                if key not in ['axis_0', 'axis_1', 'axis_2']:
-                    raise Exception("Wrong label. axis_0, axis_1 and axis_2 are expected")
-                elif key in default_roi.keys():
-                    default_roi[key] = roi[key]
-            self._roi = default_roi
-            self._metadata = self.slice_metadata(metadata)
+            self._metadata = self.slice_metadata(self._metadata_full)
         else:
-            self._roi = default_roi
-            self._metadata = metadata
+            self._metadata = self._metadata_full
         
         #setup geometry using metadata
-        if metadata['data geometry'] == 'acquisition':
+        if self._metadata_full['data geometry'] == 'acquisition':
             self._setup_acq_geometry()
         else:
             self._setup_image_geometry()
@@ -124,10 +168,6 @@ class ZEISSDataReader(object):
     def read_metadata(self):
         # Read one image to get the metadata
         _,metadata = dxchange.read_txrm(self.file_name,((0,1),(None),(None)))
-
-        # convert angles to requested unit measure, Zeiss stores in radians
-        if self.angle_unit == AcquisitionGeometry.DEGREE:
-            metadata['thetas'] = np.degrees(metadata['thetas'])
 
         # Read extra metadata
         with olefile.OleFileIO(self.file_name) as ole:
@@ -153,10 +193,10 @@ class ZEISSDataReader(object):
 
             #Configure beam and data geometries
             if xray_geometry == 1:
-                print('setting up cone beam geometry')
+                logger.info('setting up cone beam geometry')
                 metadata['beam geometry'] ='cone'
             else:
-                print('setting up parallel beam geometry')
+                logger.info('setting up parallel beam geometry')
                 metadata['beam geometry'] = 'parallel'
             if file_type == 0:
                 metadata['data geometry'] = 'acquisition'
@@ -168,9 +208,9 @@ class ZEISSDataReader(object):
         '''
         Slices metadata to configure geometry before reading data
         '''
-        image_slc = range(*self._roi['axis_0'])
-        height_slc = range(*self._roi['axis_1'])
-        width_slc = range(*self._roi['axis_2'])
+        image_slc = range(*self._roi[0])
+        height_slc = range(*self._roi[1])
+        width_slc = range(*self._roi[2])
         #These values are 0 or do not exist in TXM files and can be skipped
         if metadata['data geometry'] == 'acquisition':
             metadata['thetas'] = metadata['thetas'][image_slc]
@@ -196,11 +236,11 @@ class ZEISSDataReader(object):
                 ) \
                     .set_panel([self._metadata['image_width'], self._metadata['image_height']],\
                         pixel_size=[self._metadata['detector_pixel_size']/1000,self._metadata['detector_pixel_size']/1000])\
-                    .set_angles(self._metadata['thetas'],angle_unit=self.angle_unit)
+                    .set_angles(self._metadata['thetas'],angle_unit=AcquisitionGeometry.RADIAN)
         else:
             self._geometry = AcquisitionGeometry.create_Parallel3D()\
                     .set_panel([self._metadata['image_width'], self._metadata['image_height']])\
-                    .set_angles(self._metadata['thetas'],angle_unit=self.angle_unit)
+                    .set_angles(self._metadata['thetas'],angle_unit=AcquisitionGeometry.RADIAN)
         self._geometry.dimension_labels =  ['angle', 'vertical', 'horizontal']
 
     def _setup_image_geometry(self):
@@ -225,8 +265,7 @@ class ZEISSDataReader(object):
         # Load projections or slices from file
         slice_range = None
         if self.roi:
-            slice_range = tuple(self._roi.values())
-        print(slice_range)
+            slice_range = tuple(self._roi)
         data, _ = dxchange.read_txrm(self.file_name,slice_range)
         
         if isinstance(self._geometry,AcquisitionGeometry):
@@ -237,18 +276,14 @@ class ZEISSDataReader(object):
                 data[num,:,:] = np.roll(data[num,:,:], \
                     (int(self._metadata['x-shifts'][num]),int(self._metadata['y-shifts'][num])), \
                     axis=(1,0))
-                #data = np.flip(data, 1)
+                
             acq_data = AcquisitionData(array=data, deep_copy=False, geometry=self._geometry.copy(),suppress_warning=True)
             return acq_data
         else:
-            #data = np.flip(data, 1)
             ig_data = ImageData(array=data, deep_copy=False, geometry=self._geometry.copy())
             return ig_data
 
-    def load_projections(self):
-        '''alias of read for backward compatibility'''
-        return self.read()
-    
+
     def get_geometry(self):
         '''
         Return Acquisition (TXRM) or Image (TXM) Geometry object
@@ -258,3 +293,12 @@ class ZEISSDataReader(object):
     def get_metadata(self):
         '''return the metadata of the file'''
         return self._metadata
+
+
+class TXRMDataReader(ZEISSDataReader):
+    def __init__(self, 
+                 **kwargs):
+        warnings.warn('TXRMDataReader has been deprecated and will be removed in following version. Use ZEISSDataReader instead',
+              DeprecationWarning)
+        logger.warning('TXRMDataReader has been deprecated and will be removed in following version. Use ZEISSDataReader instead')
+        super().__init__(**kwargs)

--- a/Wrappers/Python/cil/io/__init__.py
+++ b/Wrappers/Python/cil/io/__init__.py
@@ -20,4 +20,5 @@ from .NikonDataReader import NikonDataReader
 from .TIFF import TIFFWriter
 from .TIFF import TIFFStackReader
 # from .TIFFStackReader import TIFFStackReader
-from .TXRMDataReader import TXRMDataReader
+from .ZEISSDataReader import ZEISSDataReader
+from .ZEISSDataReader import TXRMDataReader


### PR DESCRIPTION
Hi Andrew, thanks for your PR! It's in a good shape and great to have you contributing.

I've made a few changes/additions, if you want to go through anything we can discuss them on discord.
 - Header and authors list (please add your name and institution)
 - Removed kwargs from init (we're trying to do this across CIL when we touch a class)
 - Removed `angle_unit` option and just set up the geometry with the units in radians. I think it was a legacy of our old geometry class)
 - Removed the dxchange logging level as a parameter and hard code this to 'Error'. This should be needless for the user to control. But they can always get the logger and set the level from __main__ if they really want.
 - Changed `roi` to use labels specific to the geometry
 - Changed `roi` to catch `'axis':-1` and `None` in tuple
 - Changed `print` statements to use `logging.info`
 - Added back `TXRMDataReader` which uses `ZeissDataReader` but adds a deprecation warning